### PR TITLE
feat: Document Upload Service for Course Materials

### DIFF
--- a/app/models/course_models.py
+++ b/app/models/course_models.py
@@ -301,6 +301,67 @@ class Course(BaseModel):
 
 
 # ============================================================================
+# Uploaded Materials
+# ============================================================================
+
+
+class UploadedMaterial(BaseModel):
+    """Record of an uploaded material file.
+
+    Tracks files uploaded through the admin interface, including
+    their storage location and text extraction status.
+    """
+
+    id: str  # UUID
+    filename: str  # Original filename
+    storagePath: str  # Path in Materials/ folder
+    tier: str  # 'syllabus', 'course_materials', 'supplementary'
+    category: Optional[str] = None  # 'lecture', 'reading', 'case', etc.
+    fileType: str  # 'pdf', 'docx', 'image', etc.
+    fileSize: int  # Bytes
+    mimeType: str
+
+    # Timestamps
+    uploadedAt: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    uploadedBy: Optional[str] = None  # User ID when auth is implemented
+
+    # Text extraction
+    textExtracted: bool = False
+    extractedText: Optional[str] = None
+    textLength: Optional[int] = None
+    extractionError: Optional[str] = None
+    pageCount: Optional[int] = None
+
+    # Display metadata
+    title: Optional[str] = None  # Display title (defaults to filename)
+    description: Optional[str] = None
+    weekNumber: Optional[int] = None  # Link to specific week
+
+
+class MaterialUploadRequest(BaseModel):
+    """Request model for uploading a material."""
+
+    tier: str = "course_materials"  # 'syllabus', 'course_materials', 'supplementary'
+    category: Optional[str] = None  # 'lecture', 'reading', 'case', etc.
+    title: Optional[str] = None
+    description: Optional[str] = None
+    weekNumber: Optional[int] = None
+
+
+class MaterialUploadResponse(BaseModel):
+    """Response model for a successful upload."""
+
+    id: str
+    filename: str
+    storagePath: str
+    fileType: str
+    fileSize: int
+    textExtracted: bool
+    textLength: Optional[int] = None
+    extractionError: Optional[str] = None
+
+
+# ============================================================================
 # API Request/Response Models
 # ============================================================================
 

--- a/app/services/document_upload_service.py
+++ b/app/services/document_upload_service.py
@@ -1,0 +1,342 @@
+"""Document Upload Service for Course Materials.
+
+Handles file uploads to course material folders with:
+- File validation (type, size)
+- Storage path generation
+- Automatic text extraction
+- Firestore metadata storage
+"""
+
+import logging
+import mimetypes
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, List, Dict, Any
+
+from app.models.course_models import UploadedMaterial, MaterialUploadResponse
+from app.services.text_extractor import extract_text, detect_file_type
+
+logger = logging.getLogger(__name__)
+
+# Configuration
+MATERIALS_ROOT = Path("Materials")
+MAX_FILE_SIZE = 50 * 1024 * 1024  # 50MB
+
+# Supported file types and their MIME types
+SUPPORTED_TYPES = {
+    'pdf': ['application/pdf'],
+    'docx': ['application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+    'doc': ['application/msword'],
+    'pptx': ['application/vnd.openxmlformats-officedocument.presentationml.presentation'],
+    'txt': ['text/plain'],
+    'md': ['text/markdown', 'text/plain'],
+    'html': ['text/html'],
+    'png': ['image/png'],
+    'jpg': ['image/jpeg'],
+    'jpeg': ['image/jpeg'],
+    'gif': ['image/gif'],
+    'bmp': ['image/bmp'],
+}
+
+# Tier folder mapping
+TIER_FOLDERS = {
+    'syllabus': 'Syllabus',
+    'course_materials': 'Course_Materials',
+    'supplementary': 'Supplementary_Sources',
+}
+
+# Category subfolders for course_materials tier
+CATEGORY_FOLDERS = {
+    'lecture': 'Lectures',
+    'reading': 'Readings',
+    'case': 'Cases',
+    'exam': 'Exams',
+    'assignment': 'Assignments',
+}
+
+
+class UploadError(Exception):
+    """Custom exception for upload errors."""
+    pass
+
+
+def validate_file(filename: str, file_size: int, content_type: Optional[str] = None) -> str:
+    """Validate uploaded file.
+
+    Args:
+        filename: Original filename
+        file_size: File size in bytes
+        content_type: MIME type if provided
+
+    Returns:
+        Detected file extension
+
+    Raises:
+        UploadError: If validation fails
+    """
+    # Check file size
+    if file_size > MAX_FILE_SIZE:
+        raise UploadError(f"File too large. Maximum size is {MAX_FILE_SIZE // (1024*1024)}MB")
+
+    if file_size == 0:
+        raise UploadError("Empty file")
+
+    # Get extension
+    ext = Path(filename).suffix.lower().lstrip('.')
+    if not ext:
+        raise UploadError("File must have an extension")
+
+    # Check if extension is supported
+    if ext not in SUPPORTED_TYPES:
+        supported = ', '.join(SUPPORTED_TYPES.keys())
+        raise UploadError(f"Unsupported file type: .{ext}. Supported: {supported}")
+
+    # Validate MIME type if provided
+    if content_type:
+        expected_mimes = SUPPORTED_TYPES.get(ext, [])
+        # Be lenient - some browsers send generic types
+        if content_type not in expected_mimes and content_type != 'application/octet-stream':
+            logger.warning(
+                "MIME type mismatch: expected %s for .%s, got %s",
+                expected_mimes, ext, content_type
+            )
+
+    return ext
+
+
+def generate_storage_path(
+    course_id: str,
+    filename: str,
+    tier: str = 'course_materials',
+    category: Optional[str] = None
+) -> Path:
+    """Generate storage path for uploaded file.
+
+    Args:
+        course_id: Course identifier
+        filename: Original filename
+        tier: Material tier ('syllabus', 'course_materials', 'supplementary')
+        category: Optional category for course_materials ('lecture', 'reading', etc.)
+
+    Returns:
+        Path where file should be stored
+    """
+    # Get tier folder
+    tier_folder = TIER_FOLDERS.get(tier, 'Course_Materials')
+
+    # Build path
+    base_path = MATERIALS_ROOT / tier_folder / course_id
+
+    # Add category subfolder if applicable
+    if tier == 'course_materials' and category:
+        category_folder = CATEGORY_FOLDERS.get(category, category.title())
+        base_path = base_path / category_folder
+
+    # Ensure unique filename
+    safe_filename = sanitize_filename(filename)
+    target_path = base_path / safe_filename
+
+    # If file exists, add UUID suffix
+    if target_path.exists():
+        stem = target_path.stem
+        suffix = target_path.suffix
+        unique_id = uuid.uuid4().hex[:8]
+        safe_filename = f"{stem}_{unique_id}{suffix}"
+        target_path = base_path / safe_filename
+
+    return target_path
+
+
+def sanitize_filename(filename: str) -> str:
+    """Sanitize filename for safe storage.
+
+    Removes or replaces unsafe characters while preserving readability.
+    """
+    # Keep alphanumeric, spaces, dots, hyphens, underscores
+    safe_chars = []
+    for char in filename:
+        if char.isalnum() or char in ' .-_':
+            safe_chars.append(char)
+        elif char in '/\\:*?"<>|':
+            safe_chars.append('_')
+
+    result = ''.join(safe_chars).strip()
+
+    # Ensure not empty
+    if not result or result == '.':
+        result = f"file_{uuid.uuid4().hex[:8]}"
+
+    return result
+
+
+async def save_uploaded_file(
+    file_content: bytes,
+    filename: str,
+    course_id: str,
+    tier: str = 'course_materials',
+    category: Optional[str] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    week_number: Optional[int] = None,
+    content_type: Optional[str] = None
+) -> UploadedMaterial:
+    """Save uploaded file and extract text.
+
+    Args:
+        file_content: Raw file bytes
+        filename: Original filename
+        course_id: Course to associate with
+        tier: Material tier
+        category: Material category
+        title: Display title
+        description: Material description
+        week_number: Associated week number
+        content_type: MIME type
+
+    Returns:
+        UploadedMaterial record
+
+    Raises:
+        UploadError: If upload fails
+    """
+    # Validate file
+    file_ext = validate_file(filename, len(file_content), content_type)
+
+    # Generate storage path
+    storage_path = generate_storage_path(course_id, filename, tier, category)
+
+    # Create directories
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Save file
+    try:
+        storage_path.write_bytes(file_content)
+        logger.info("Saved file to %s", storage_path)
+    except Exception as e:
+        raise UploadError(f"Failed to save file: {e}") from e
+
+    # Detect file type for extraction
+    detected_type = detect_file_type(storage_path)
+
+    # Extract text
+    extraction_result = extract_text(storage_path)
+
+    # Determine MIME type
+    mime_type = content_type or mimetypes.guess_type(filename)[0] or 'application/octet-stream'
+
+    # Create material record
+    material = UploadedMaterial(
+        id=str(uuid.uuid4()),
+        filename=filename,
+        storagePath=str(storage_path),
+        tier=tier,
+        category=category,
+        fileType=detected_type,
+        fileSize=len(file_content),
+        mimeType=mime_type,
+        uploadedAt=datetime.now(timezone.utc),
+        textExtracted=extraction_result.success,
+        extractedText=extraction_result.text if extraction_result.success else None,
+        textLength=len(extraction_result.text) if extraction_result.success else None,
+        extractionError=extraction_result.error if not extraction_result.success else None,
+        pageCount=extraction_result.metadata.get('num_pages') if extraction_result.metadata else None,
+        title=title or filename,
+        description=description,
+        weekNumber=week_number,
+    )
+
+    return material
+
+
+async def delete_material_file(storage_path: str) -> bool:
+    """Delete a material file from storage.
+
+    Args:
+        storage_path: Path to the file
+
+    Returns:
+        True if deleted, False if not found
+    """
+    path = Path(storage_path)
+    if path.exists():
+        try:
+            path.unlink()
+            logger.info("Deleted file: %s", storage_path)
+
+            # Clean up empty parent directories
+            parent = path.parent
+            while parent != MATERIALS_ROOT and not any(parent.iterdir()):
+                parent.rmdir()
+                parent = parent.parent
+
+            return True
+        except Exception as e:
+            logger.error("Failed to delete file %s: %s", storage_path, e)
+            raise UploadError(f"Failed to delete file: {e}") from e
+    return False
+
+
+def list_course_materials(course_id: str) -> List[Dict[str, Any]]:
+    """List all material files for a course.
+
+    Scans the Materials folders for files belonging to the course.
+
+    Args:
+        course_id: Course identifier
+
+    Returns:
+        List of material info dicts
+    """
+    materials = []
+
+    for tier, folder in TIER_FOLDERS.items():
+        course_folder = MATERIALS_ROOT / folder / course_id
+        if course_folder.exists():
+            for file_path in course_folder.rglob('*'):
+                if file_path.is_file():
+                    # Determine category from path
+                    category = None
+                    if tier == 'course_materials':
+                        relative = file_path.relative_to(course_folder)
+                        if len(relative.parts) > 1:
+                            category = relative.parts[0].lower()
+
+                    materials.append({
+                        'path': str(file_path),
+                        'filename': file_path.name,
+                        'tier': tier,
+                        'category': category,
+                        'size': file_path.stat().st_size,
+                        'modified': datetime.fromtimestamp(
+                            file_path.stat().st_mtime,
+                            tz=timezone.utc
+                        ).isoformat(),
+                    })
+
+    return materials
+
+
+def get_supported_extensions() -> List[str]:
+    """Get list of supported file extensions."""
+    return list(SUPPORTED_TYPES.keys())
+
+
+def get_tier_options() -> List[Dict[str, str]]:
+    """Get available tier options for UI."""
+    return [
+        {'value': 'syllabus', 'label': 'Syllabus'},
+        {'value': 'course_materials', 'label': 'Course Materials'},
+        {'value': 'supplementary', 'label': 'Supplementary Sources'},
+    ]
+
+
+def get_category_options() -> List[Dict[str, str]]:
+    """Get available category options for UI."""
+    return [
+        {'value': 'lecture', 'label': 'Lecture'},
+        {'value': 'reading', 'label': 'Reading'},
+        {'value': 'case', 'label': 'Case Study'},
+        {'value': 'exam', 'label': 'Exam/Practice'},
+        {'value': 'assignment', 'label': 'Assignment'},
+    ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ fastapi>=0.109.0
 uvicorn[standard]>=0.27.0
 pydantic>=2.10.0
 pydantic-settings>=2.1.0
+python-multipart>=0.0.6  # Required for file uploads
 
 # Anthropic API
 anthropic>=0.18.1

--- a/tests/test_document_upload.py
+++ b/tests/test_document_upload.py
@@ -1,0 +1,308 @@
+"""Tests for Document Upload Service."""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.document_upload_service import (
+    validate_file,
+    generate_storage_path,
+    sanitize_filename,
+    save_uploaded_file,
+    delete_material_file,
+    list_course_materials,
+    get_supported_extensions,
+    get_tier_options,
+    get_category_options,
+    UploadError,
+    MAX_FILE_SIZE,
+    SUPPORTED_TYPES,
+    TIER_FOLDERS,
+    CATEGORY_FOLDERS,
+)
+
+
+class TestValidateFile:
+    """Tests for file validation."""
+
+    def test_valid_pdf(self):
+        """Test validating a valid PDF file."""
+        ext = validate_file("document.pdf", 1024, "application/pdf")
+        assert ext == "pdf"
+
+    def test_valid_docx(self):
+        """Test validating a valid DOCX file."""
+        ext = validate_file("document.docx", 1024)
+        assert ext == "docx"
+
+    def test_valid_image(self):
+        """Test validating valid image files."""
+        for ext_type in ['png', 'jpg', 'jpeg', 'gif', 'bmp']:
+            ext = validate_file(f"image.{ext_type}", 1024)
+            assert ext == ext_type
+
+    def test_valid_text(self):
+        """Test validating text files."""
+        for ext_type in ['txt', 'md', 'html']:
+            ext = validate_file(f"file.{ext_type}", 1024)
+            assert ext == ext_type
+
+    def test_file_too_large(self):
+        """Test that oversized files are rejected."""
+        with pytest.raises(UploadError) as exc_info:
+            validate_file("document.pdf", MAX_FILE_SIZE + 1)
+        assert "too large" in str(exc_info.value).lower()
+
+    def test_empty_file(self):
+        """Test that empty files are rejected."""
+        with pytest.raises(UploadError) as exc_info:
+            validate_file("document.pdf", 0)
+        assert "Empty" in str(exc_info.value)
+
+    def test_no_extension(self):
+        """Test that files without extensions are rejected."""
+        with pytest.raises(UploadError) as exc_info:
+            validate_file("document", 1024)
+        assert "extension" in str(exc_info.value).lower()
+
+    def test_unsupported_extension(self):
+        """Test that unsupported extensions are rejected."""
+        with pytest.raises(UploadError) as exc_info:
+            validate_file("document.xyz", 1024)
+        assert "Unsupported" in str(exc_info.value)
+
+
+class TestSanitizeFilename:
+    """Tests for filename sanitization."""
+
+    def test_normal_filename(self):
+        """Test that normal filenames are preserved."""
+        assert sanitize_filename("document.pdf") == "document.pdf"
+
+    def test_filename_with_spaces(self):
+        """Test that spaces are preserved."""
+        assert sanitize_filename("my document.pdf") == "my document.pdf"
+
+    def test_filename_with_unsafe_chars(self):
+        """Test that unsafe characters are replaced."""
+        result = sanitize_filename("file:name*test?.pdf")
+        assert ":" not in result
+        assert "*" not in result
+        assert "?" not in result
+        assert result.endswith(".pdf")
+
+    def test_empty_filename(self):
+        """Test that empty filenames get a default."""
+        result = sanitize_filename("")
+        assert result.startswith("file_")
+
+
+class TestGenerateStoragePath:
+    """Tests for storage path generation."""
+
+    def test_syllabus_tier(self):
+        """Test path generation for syllabus tier."""
+        path = generate_storage_path("LLS", "syllabus.pdf", tier="syllabus")
+        assert "Syllabus" in str(path)
+        assert "LLS" in str(path)
+
+    def test_course_materials_tier(self):
+        """Test path generation for course_materials tier."""
+        path = generate_storage_path("LLS", "lecture.pdf", tier="course_materials")
+        assert "Course_Materials" in str(path)
+        assert "LLS" in str(path)
+
+    def test_supplementary_tier(self):
+        """Test path generation for supplementary tier."""
+        path = generate_storage_path("LLS", "article.pdf", tier="supplementary")
+        assert "Supplementary_Sources" in str(path)
+        assert "LLS" in str(path)
+
+    def test_with_category(self):
+        """Test path generation with category."""
+        path = generate_storage_path(
+            "LLS", "lecture1.pdf",
+            tier="course_materials",
+            category="lecture"
+        )
+        assert "Lectures" in str(path)
+
+    def test_unique_filename_on_collision(self):
+        """Test that colliding filenames get unique suffixes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a temporary Materials directory structure
+            with patch('app.services.document_upload_service.MATERIALS_ROOT', Path(tmpdir)):
+                # Create first path
+                path1 = generate_storage_path("LLS", "test.pdf")
+                path1.parent.mkdir(parents=True, exist_ok=True)
+                path1.write_text("test")
+
+                # Generate another path - should be unique
+                path2 = generate_storage_path("LLS", "test.pdf")
+                assert path1 != path2
+
+
+class TestUtilityFunctions:
+    """Tests for utility functions."""
+
+    def test_get_supported_extensions(self):
+        """Test getting supported extensions."""
+        extensions = get_supported_extensions()
+        assert "pdf" in extensions
+        assert "docx" in extensions
+        assert "png" in extensions
+        assert "txt" in extensions
+
+    def test_get_tier_options(self):
+        """Test getting tier options."""
+        options = get_tier_options()
+        assert len(options) == 3
+        values = [o["value"] for o in options]
+        assert "syllabus" in values
+        assert "course_materials" in values
+        assert "supplementary" in values
+
+    def test_get_category_options(self):
+        """Test getting category options."""
+        options = get_category_options()
+        assert len(options) >= 4
+        values = [o["value"] for o in options]
+        assert "lecture" in values
+        assert "reading" in values
+        assert "case" in values
+
+
+class TestSaveUploadedFile:
+    """Tests for file saving."""
+
+    @pytest.mark.asyncio
+    async def test_save_text_file(self):
+        """Test saving a text file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('app.services.document_upload_service.MATERIALS_ROOT', Path(tmpdir)):
+                content = b"This is test content for the file."
+
+                material = await save_uploaded_file(
+                    file_content=content,
+                    filename="test.txt",
+                    course_id="TEST-COURSE",
+                    tier="course_materials"
+                )
+
+                assert material.filename == "test.txt"
+                assert material.fileSize == len(content)
+                assert material.fileType == "text"
+                assert material.textExtracted is True
+                assert "test content" in material.extractedText
+
+    @pytest.mark.asyncio
+    async def test_save_with_metadata(self):
+        """Test saving with title and description."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('app.services.document_upload_service.MATERIALS_ROOT', Path(tmpdir)):
+                material = await save_uploaded_file(
+                    file_content=b"content",
+                    filename="doc.txt",
+                    course_id="TEST",
+                    title="My Document",
+                    description="A test document",
+                    week_number=3
+                )
+
+                assert material.title == "My Document"
+                assert material.description == "A test document"
+                assert material.weekNumber == 3
+
+    @pytest.mark.asyncio
+    async def test_save_invalid_file_raises(self):
+        """Test that invalid files raise UploadError."""
+        with pytest.raises(UploadError):
+            await save_uploaded_file(
+                file_content=b"",
+                filename="empty.pdf",
+                course_id="TEST"
+            )
+
+
+class TestDeleteMaterialFile:
+    """Tests for file deletion."""
+
+    @pytest.mark.asyncio
+    async def test_delete_existing_file(self):
+        """Test deleting an existing file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a test file
+            test_file = Path(tmpdir) / "test.txt"
+            test_file.write_text("content")
+
+            result = await delete_material_file(str(test_file))
+            assert result is True
+            assert not test_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_file(self):
+        """Test deleting a non-existent file returns False."""
+        result = await delete_material_file("/nonexistent/path/file.txt")
+        assert result is False
+
+
+class TestListCourseMaterials:
+    """Tests for listing course materials."""
+
+    def test_list_empty_course(self):
+        """Test listing materials for a course with no files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch('app.services.document_upload_service.MATERIALS_ROOT', Path(tmpdir)):
+                materials = list_course_materials("NONEXISTENT")
+                assert materials == []
+
+    def test_list_with_files(self):
+        """Test listing materials for a course with files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            materials_root = Path(tmpdir)
+
+            # Create some test files
+            course_dir = materials_root / "Course_Materials" / "TEST"
+            course_dir.mkdir(parents=True)
+            (course_dir / "lecture.pdf").write_text("content")
+
+            syllabus_dir = materials_root / "Syllabus" / "TEST"
+            syllabus_dir.mkdir(parents=True)
+            (syllabus_dir / "syllabus.pdf").write_text("content")
+
+            with patch('app.services.document_upload_service.MATERIALS_ROOT', materials_root):
+                materials = list_course_materials("TEST")
+
+                assert len(materials) == 2
+                filenames = [m["filename"] for m in materials]
+                assert "lecture.pdf" in filenames
+                assert "syllabus.pdf" in filenames
+
+
+class TestConstants:
+    """Tests for module constants."""
+
+    def test_max_file_size(self):
+        """Test that max file size is reasonable."""
+        assert MAX_FILE_SIZE == 50 * 1024 * 1024  # 50MB
+
+    def test_supported_types_complete(self):
+        """Test that all expected types are supported."""
+        expected = ['pdf', 'docx', 'doc', 'txt', 'md', 'html', 'png', 'jpg', 'jpeg']
+        for ext in expected:
+            assert ext in SUPPORTED_TYPES
+
+    def test_tier_folders_mapping(self):
+        """Test tier to folder mapping."""
+        assert TIER_FOLDERS["syllabus"] == "Syllabus"
+        assert TIER_FOLDERS["course_materials"] == "Course_Materials"
+        assert TIER_FOLDERS["supplementary"] == "Supplementary_Sources"
+
+    def test_category_folders_mapping(self):
+        """Test category to folder mapping."""
+        assert CATEGORY_FOLDERS["lecture"] == "Lectures"
+        assert CATEGORY_FOLDERS["reading"] == "Readings"
+        assert CATEGORY_FOLDERS["case"] == "Cases"


### PR DESCRIPTION
## Summary

- Implements file upload functionality for course materials (closes #45)
- Supports PDF, DOCX, images, and text files up to 50MB
- Automatic text extraction using the Text Extraction Service
- Files stored in appropriate Materials folder structure by tier
- Upload metadata stored in Firestore subcollection

## API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/api/admin/courses/{id}/upload` | Upload a file |
| GET | `/api/admin/courses/{id}/uploads` | List all uploads |
| GET | `/api/admin/courses/{id}/uploads/{id}` | Get upload details |
| DELETE | `/api/admin/courses/{id}/uploads/{id}` | Delete upload |
| POST | `/api/admin/courses/{id}/uploads/{id}/re-extract` | Re-run text extraction |
| GET | `/api/admin/courses/upload/options` | Get form options |

## New Files

- `app/services/document_upload_service.py` - Core upload service
- `tests/test_document_upload.py` - 31 unit tests

## Modified Files

- `app/models/course_models.py` - Added UploadedMaterial model
- `app/routes/admin_courses.py` - Added upload endpoints
- `requirements.txt` - Added python-multipart dependency

## Test plan

- [x] All 174 tests pass
- [x] Unit tests for file validation
- [x] Unit tests for path generation
- [x] Unit tests for file save/delete
- [ ] Manual test: Upload PDF via API
- [ ] Manual test: Upload DOCX via API
- [ ] Manual test: Upload image via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)