### PR TITLE
fix: Add Files API beta header to all API calls

### DIFF
--- a/app/services/files_api_service.py
+++ b/app/services/files_api_service.py
@@ -153,10 +153,11 @@ Return ONLY valid JSON:
             "text": prompt_text
         })
 
-        # Call API
-        response = await self.client.messages.create(
+        # Call API with Files API beta
+        response = await self.client.beta.messages.create(
             model="claude-sonnet-4-20250514",
             max_tokens=4000,
+            betas=[self.beta_header],
             messages=[{
                 "role": "user",
                 "content": content_blocks
@@ -250,9 +251,10 @@ Use visual formatting:
             "text": prompt_text
         })
 
-        response = await self.client.messages.create(
+        response = await self.client.beta.messages.create(
             model="claude-sonnet-4-20250514",
             max_tokens=3000,
+            betas=[self.beta_header],
             messages=[{"role": "user", "content": content_blocks}]
         )
 
@@ -311,9 +313,10 @@ Cite page numbers if available.""" % (article, code)
             "text": prompt_text
         })
 
-        response = await self.client.messages.create(
+        response = await self.client.beta.messages.create(
             model="claude-sonnet-4-20250514",
             max_tokens=2500,
+            betas=[self.beta_header],
             messages=[{"role": "user", "content": content_blocks}]
         )
 
@@ -388,9 +391,10 @@ Use proper legal analysis method and cite articles.""" % (topic, case_facts)
             "text": prompt_text
         })
 
-        response = await self.client.messages.create(
+        response = await self.client.beta.messages.create(
             model="claude-sonnet-4-20250514",
             max_tokens=2500,
+            betas=[self.beta_header],
             messages=[{"role": "user", "content": content_blocks}]
         )
 
@@ -459,9 +463,10 @@ Include:
             "text": prompt_text
         })
 
-        response = await self.client.messages.create(
+        response = await self.client.beta.messages.create(
             model="claude-sonnet-4-20250514",
             max_tokens=3000,
+            betas=[self.beta_header],
             messages=[{"role": "user", "content": content_blocks}]
         )
 


### PR DESCRIPTION
## Summary

Fixes #60 - Quiz generation 500 Internal Server Error

## Root Cause

The Anthropic Files API requires using `client.beta.messages.create()` with `betas=['files-api-2025-04-14']` parameter to enable document source type `'file'`.

Without this beta header, the API returns:
```
Input tag 'file' found using 'type' does not match any of the expected tags: 'base64', 'content', 'text', 'url'
```

The `beta_header` was defined in the service class but never actually passed to the API calls.

## Changes

- Updated `generate_quiz_from_files()` to use `beta.messages.create()`
- Updated `generate_study_guide()` to use `beta.messages.create()`
- Updated `explain_article()` to use `beta.messages.create()`
- Updated `generate_case_analysis()` to use `beta.messages.create()`
- Updated `generate_flashcards()` to use `beta.messages.create()`
- All calls now pass `betas=[self.beta_header]` parameter

## Testing

- All 36 tests in `test_files_content.py` pass
- Verified the API now correctly processes the beta header (no longer returns invalid_request_error)

## Note

After this fix, if you see `File not found` errors, it means the files in `file_ids.json` have expired from Anthropic's storage and need to be re-uploaded using the upload script.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author