### PR TITLE
fix: Refactor study guide to use text extraction architecture (Issue #19)

### DIFF
--- a/app/routes/files_content.py
+++ b/app/routes/files_content.py
@@ -355,18 +355,15 @@ async def generate_study_guide(request: FilesStudyGuideRequest):
         # Build topic description
         if request.weeks:
             topic_description = f"Course '{request.course_id}' - Weeks {request.weeks}"
-            # For specific weeks, we need to call once per week
-            # The service will handle filtering
-            week_number = request.weeks[0] if len(request.weeks) == 1 else None
         else:
             topic_description = f"Course '{request.course_id}' - All Materials"
-            week_number = None
 
         # Generate study guide using the new text extraction approach
+        # Pass week_numbers list (or None for all materials)
         guide = await service.generate_study_guide_from_course(
             course_id=request.course_id,
             topic=topic_description,
-            week_number=week_number
+            week_numbers=request.weeks  # Pass full list of weeks
         )
 
         response = {
@@ -380,7 +377,7 @@ async def generate_study_guide(request: FilesStudyGuideRequest):
                 "The 'topic' parameter is deprecated and was ignored. "
                 "Study guides now use course materials."
             )
-            logger.info("Deprecated 'topic' parameter used: %s", request.topic)
+            logger.warning("Deprecated 'topic' parameter used: %s", request.topic)
 
         # Add course context to response
         _add_course_context(response, course_id=request.course_id, weeks=request.weeks)

--- a/tests/test_files_content.py
+++ b/tests/test_files_content.py
@@ -558,7 +558,7 @@ class TestCourseAwareStudyGuideEndpoint:
             mock_service.generate_study_guide_from_course.assert_called_once_with(
                 course_id="LLS-2025-2026",
                 topic="Course 'LLS-2025-2026' - All Materials",
-                week_number=None
+                week_numbers=None
             )
 
     def test_study_guide_with_course_id_and_single_week(self, client):
@@ -583,11 +583,11 @@ class TestCourseAwareStudyGuideEndpoint:
             mock_service.generate_study_guide_from_course.assert_called_once_with(
                 course_id="LLS-2025-2026",
                 topic="Course 'LLS-2025-2026' - Weeks [2]",
-                week_number=2
+                week_numbers=[2]
             )
 
     def test_study_guide_with_multiple_weeks(self, client):
-        """Test study guide with multiple weeks."""
+        """Test study guide with multiple weeks fetches materials for all weeks."""
         mock_service = MagicMock()
         mock_service.generate_study_guide_from_course = AsyncMock(
             return_value="# Multi-week Guide\n\nContent..."
@@ -605,8 +605,12 @@ class TestCourseAwareStudyGuideEndpoint:
             assert response.status_code == 200
             data = response.json()
             assert data.get("weeks") == [2, 3]
-            # Multiple weeks means week_number is None (service will handle internally)
-            mock_service.generate_study_guide_from_course.assert_called_once()
+            # Multiple weeks are now passed to the service
+            mock_service.generate_study_guide_from_course.assert_called_once_with(
+                course_id="LLS-2025-2026",
+                topic="Course 'LLS-2025-2026' - Weeks [2, 3]",
+                week_numbers=[2, 3]
+            )
 
     def test_study_guide_weeks_validation(self, client):
         """Test study guide rejects invalid week numbers via Pydantic."""


### PR DESCRIPTION
## Summary

Refactors the Study Guide Generator to use the new text extraction architecture, fixing the 500 error caused by the removed `file_ids` attribute.

## Problem

The `generate_study_guide()` method was still using the old approach:
- Called `self.get_file_id(key)` which no longer exists
- Used Anthropic's Files API document format with `file_id`
- Failed with error: `'FilesAPIService' object has no attribute 'file_ids'`

## Solution

Refactored to match `generate_quiz_from_course()` pattern:

### `app/services/files_api_service.py`
- Renamed method to `generate_study_guide_from_course()`
- Changed signature: accepts `course_id` instead of `file_keys`
- Uses `get_course_materials_with_text()` to fetch materials with extracted text
- Builds text content blocks instead of deprecated file_id document blocks
- Removed beta header (not needed for text-based approach)
- Increased max_tokens to 4000 for comprehensive guides

### `app/routes/files_content.py`
- Updated `/study-guide` endpoint to require `course_id`
- Removed legacy mode (no longer supported without course_id)
- Simplified error handling (ValueError for no materials → 400)
- Cleaned up documentation

### `tests/test_files_content.py`
- Updated all study guide tests to mock new method
- Removed tests for deprecated legacy mode
- Added tests for new required `course_id` parameter

## API Changes

### Before
```json
// These all worked
{"topic": "Criminal Law"}
{"course_id": "LLS-2025-2026"}
{}
```

### After
```json
// Now requires course_id
{"course_id": "LLS-2025-2026"}
{"course_id": "LLS-2025-2026", "weeks": [1, 2]}
```

## Testing

- ✅ 372 tests pass (1 pre-existing PyMuPDF failure)
- ✅ All 11 study guide tests pass
- ✅ Manual testing shows API working (rate limited due to large content)

## Breaking Changes

- `course_id` is now required for study guide generation
- Legacy mode (empty request or topic-only) no longer supported
- The old `generate_study_guide(topic, file_keys)` method signature is removed

Closes #19

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author