### PR TITLE
Fix: Anthropic Cost API endpoint bug fixes (#233)

### DIFF
--- a/app/routes/admin_usage.py
+++ b/app/routes/admin_usage.py
@@ -1054,13 +1054,13 @@ async def get_anthropic_cost(
             end_date=end_date,
         )
 
-        # Convert from cents to dollars
-        total_cost_usd = float(report.total_amount) / 100.0
+        # Get total cost - Anthropic API returns amounts already in USD (not cents)
+        total_cost_usd = report.get_total_amount()
 
         return AnthropicCostData(
             total_cost_usd=round(total_cost_usd, 6),
-            start_date=report.start_date,
-            end_date=report.end_date,
+            start_date=start_date.isoformat(),
+            end_date=end_date.isoformat(),
         )
 
     except ValueError as e:


### PR DESCRIPTION
## Summary

Fixes critical bugs in the `/api/admin/usage/anthropic/cost` endpoint that caused incorrect Anthropic cost display.

## Related Issues

- Fixes #233

## Changes

### Bug Fixes in `app/routes/admin_usage.py`

1. **Fixed attribute access**: Changed `report.total_amount` → `report.get_total_amount()`
   - The `AnthropicCostReport` model has a **method** `get_total_amount()`, not an attribute `total_amount`
   - This would have caused an `AttributeError` at runtime

2. **Removed incorrect division by 100**: The Anthropic API returns amounts already in USD, not cents
   - Before: `float(report.total_amount) / 100.0`
   - After: `report.get_total_amount()`

3. **Fixed date attribute access**: The report doesn't have `start_date`/`end_date` attributes
   - Before: `start_date=report.start_date, end_date=report.end_date`
   - After: `start_date=start_date.isoformat(), end_date=end_date.isoformat()` (using input parameters)

## Testing

- All 13 usage tracking tests pass
- Syntax check passes
- The reconciliation endpoint (`/api/admin/usage/reconciliation`) already had the correct implementation and was used as reference

## Before/After

**Before (broken):**
```python
# Convert from cents to dollars  <-- Wrong! Already in USD
total_cost_usd = float(report.total_amount) / 100.0  # AttributeError: no total_amount attr

return AnthropicCostData(
    total_cost_usd=round(total_cost_usd, 6),
    start_date=report.start_date,  # AttributeError
    end_date=report.end_date,      # AttributeError
)
```

**After (fixed):**
```python
# Get total cost - Anthropic API returns amounts already in USD (not cents)
total_cost_usd = report.get_total_amount()

return AnthropicCostData(
    total_cost_usd=round(total_cost_usd, 6),
    start_date=start_date.isoformat(),
    end_date=end_date.isoformat(),
)
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author