### PR TITLE
Fix: Add comprehensive LLM usage tracking to all Anthropic API calls

### DIFF
--- a/app/services/anthropic_client.py
+++ b/app/services/anthropic_client.py
@@ -400,7 +400,8 @@ async def get_simple_response(
 
 async def generate_essay_question(
     topic: str,
-    course_context: Optional[str] = None
+    course_context: Optional[str] = None,
+    user_context: Optional[UserContext] = None,
 ) -> Dict:
     """
     Generate an essay question for a given topic.
@@ -408,6 +409,7 @@ async def generate_essay_question(
     Args:
         topic: The topic to generate a question about
         course_context: Optional course material context
+        user_context: User context for usage tracking
 
     Returns:
         Dictionary with question, topic, key_concepts, guidance
@@ -427,6 +429,15 @@ async def generate_essay_question(
                 "role": "user",
                 "content": user_message
             }]
+        )
+
+        # Track usage
+        await _track_llm_usage(
+            response=response,
+            user_context=user_context,
+            model="claude-sonnet-4-20250514",
+            operation_type="essay_question",
+            request_metadata={"topic": topic},
         )
 
         response_text = response.content[0].text
@@ -464,7 +475,8 @@ async def evaluate_essay_answer(
     answer: str,
     topic: str,
     key_concepts: Optional[List[str]] = None,
-    course_context: Optional[str] = None
+    course_context: Optional[str] = None,
+    user_context: Optional[UserContext] = None,
 ) -> Dict:
     """
     Evaluate a student's essay answer.
@@ -475,6 +487,7 @@ async def evaluate_essay_answer(
         topic: The topic being assessed
         key_concepts: Optional list of concepts that should be addressed
         course_context: Optional course material for reference
+        user_context: User context for usage tracking
 
     Returns:
         Dictionary with grade, feedback, strengths, improvements
@@ -504,6 +517,15 @@ async def evaluate_essay_answer(
                 "role": "user",
                 "content": user_message
             }]
+        )
+
+        # Track usage
+        await _track_llm_usage(
+            response=response,
+            user_context=user_context,
+            model="claude-sonnet-4-20250514",
+            operation_type="essay_evaluation",
+            request_metadata={"topic": topic},
         )
 
         response_text = response.content[0].text


### PR DESCRIPTION
## Overview

This PR addresses the **root cause** of the usage tracking discrepancy identified in issue #236, where internal tracking was capturing only ~10% of actual Anthropic API usage.

### The Problem
- **Internal tracking**: 271.5K input tokens, $0.98 cost, 5 requests
- **Anthropic console**: 2.4M input tokens, $848 cost
- **Variance**: -88% to -100% on all metrics

The earlier fix in PR #234 addressed a symptom (broken display endpoint), but the root cause was that **most Anthropic API calls were NOT being tracked for usage**.

## Implements
- Fixes #236

## Changes

### Backend Services

| File | Function(s) | Change |
|------|-------------|--------|
| `app/services/anthropic_client.py` | `generate_essay_question()`, `evaluate_essay_answer()` | Added `user_context` parameter and `_track_llm_usage()` calls |
| `app/services/materials_scanner.py` | `enhance_titles_with_ai()` | Converted to `AsyncAnthropic`, added `_track_system_usage()` helper |
| `app/services/files_api_service.py` | `generate_quiz()`, `explain_article()`, `generate_case_analysis()`, `generate_flashcards()`, `generate_flashcards_from_course()` | Added `user_context` parameter and usage tracking |
| `app/services/syllabus_extractor.py` | `extract_course_data()`, `extract_topics_from_syllabus()` | Added `_track_system_usage()` helper and tracking calls |

### Routes

| File | Endpoint(s) | Change |
|------|-------------|--------|
| `app/routes/assessment.py` | `POST /api/assessment/generate`, `POST /api/assessment/submit` | Pass `user_context` to service functions |
| `app/routes/upload.py` | `POST /api/upload/{material_id}/analyze` | Added usage tracking after content analysis API call |

## Technical Details

### Tracking Patterns Used

1. **User-attributed tracking** - For operations with a logged-in user:
   ```python
   user_context = UserContext(
       email=current_user.email,
       user_id=current_user.user_id,
       course_id=course_id,
   )
   await track_llm_usage_from_response(
       response=response,
       user_context=user_context,
       operation_type="content_analysis",
       model="claude-sonnet-4-20250514",
       request_metadata={"material_id": material_id},
   )
   ```

2. **System-level tracking** - For admin/system operations without user context:
   ```python
   async def _track_system_usage(response, model, operation_type):
       await get_usage_tracking_service().record_usage(
           user_email="system@internal",
           user_id="system",
           model=model,
           operation_type=operation_type,
           ...
       )
   ```

### Operation Types Added
- `essay_question` - Essay question generation
- `essay_evaluation` - Essay answer evaluation
- `title_enhancement` - Material title enhancement (system)
- `content_analysis` - Content analysis during upload
- `quiz_files_api` - Quiz generation via Files API
- `article_explanation` - Legal article explanation
- `case_analysis` - Case analysis generation
- `flashcard_files_api` - Flashcard generation via Files API
- `flashcard_course` - Flashcard generation from course materials
- `syllabus_extraction` - Syllabus data extraction (system)
- `topic_extraction` - Topic extraction from syllabus (system)

## Testing

- [x] All syntax checks pass (`python -m py_compile`)
- [x] 816/854 tests pass (pre-existing failures unrelated to this change)
- [x] All usage tracking tests pass (13/13)

### Pre-existing Test Failures (Not Related to This PR)
- `test_badge_*` - Badge system mock issues
- `test_streak_system.py` - Streak system mock issues
- `test_docker_integration.py` - Docker infrastructure test
- `test_text_extractor.py` - Missing PyMuPDF package
- `test_files_content.py::TestCourseAwareFlashcardsEndpoint` - Tests calling functions without required `topic` argument

## Deployment Notes

- No breaking changes
- No database migrations required
- No environment variable changes
- Backward compatible - `user_context` parameter is optional

## Verification After Deployment

1. Generate some content (quiz, flashcards, study guide)
2. Check `/api/admin/usage` to verify new records appear
3. Compare internal totals with Anthropic console after a day of usage

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author