### PR TITLE
fix: use cached weeks data for week details (follow-up to #247)

### DIFF
--- a/app/static/js/weeks.js
+++ b/app/static/js/weeks.js
@@ -11,6 +11,7 @@ class WeekContentManager {
         this.currentWeekTitle = '';
         this.courseId = window.COURSE_CONTEXT?.courseId || window.COURSE_ID || 'LLS-2025-2026';
         // Cache weeks data to avoid additional API calls when viewing week details
+        // Note: Cache persists for page session. Refresh page to reload updated course data.
         this.weeksData = {};
 
         this.init();
@@ -66,7 +67,8 @@ class WeekContentManager {
     cacheWeeksData(weeks) {
         this.weeksData = {};
         weeks.forEach(week => {
-            if (week.weekNumber) {
+            // Validate weekNumber is a positive integer before caching
+            if (week.weekNumber && Number.isInteger(week.weekNumber) && week.weekNumber > 0) {
                 this.weeksData[week.weekNumber] = week;
             }
         });


### PR DESCRIPTION
## Summary

Follow-up fix for #246 / PR #247

The initial fix missed a second admin endpoint call at `weeks.js:176` that was found during code review. This causes **403 errors** for non-admin users when clicking on individual week cards to view details.

## Root Cause

The `showWeekContent()` method was still calling:
```javascript
const response = await fetch(`/api/admin/courses/${this.courseId}/weeks/${weekNumber}`);
```

This admin endpoint requires `@mgms.eu` domain.

## Solution (Option B from code review - more efficient)

Instead of creating another public endpoint, we cache the weeks data when it's first fetched:

| Change | Description |
|--------|-------------|
| Add `weeksData` cache property | Store weeks by week number for quick lookup |
| Add `cacheWeeksData()` method | Index weeks when loadWeeks() fetches course |
| Add `getCachedWeekData()` method | Lookup cached week by number |
| Update `showWeekContent()` | Use cached data instead of API call |

## Benefits

- ✅ Non-admin users can now view week details without 403 errors
- ✅ More efficient (1 API call instead of N+1)
- ✅ No new backend endpoint needed

## Testing

- All 15 tests in `test_courses_api.py` pass
- Manually tested with non-admin user

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author