### PR TITLE
Potential fix for code scanning alert no. 124: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
     "testMatch": [
       "**/tests/**/*.test.js"
     ]
-  }
+  },
+  "dependencies": {
+    "dompurify": "^3.3.1"
+}
 }


### PR DESCRIPTION
Potential fix for [https://github.com/TEJ42000/ALLMS/security/code-scanning/124](https://github.com/TEJ42000/ALLMS/security/code-scanning/124)

In general, to fix this kind of problem you must ensure that content derived from untrusted DOM text is not directly interpreted as markup (HTML/SVG) without a robust sanitization step or strict constraints that eliminate active content. Either (1) keep the data in text form via `textContent` (no markup interpretation), or (2) pass it through a trusted sanitizer that strips unsafe constructs before parsing or inserting it into the DOM.

For this specific code, the best fix with minimal functional change is to sanitize the `svg` string returned by `mermaid.render` before feeding it into `DOMParser`. We can do this by introducing DOMPurify (a well‑known client-side sanitization library) and using it to sanitize the SVG string in SVG mode. That way, even if an attacker manages to craft a Mermaid diagram that causes Mermaid to emit dangerous SVG, DOMPurify will remove scripts, event handlers, `javascript:` URLs, and other active content before the SVG is parsed and attached to the DOM. The rest of the flow (detect mermaid code, render, build container and title, replace `<pre>`) stays unchanged.

Concretely, within `app/static/js/app.js`:

1. Add an import (or require) of DOMPurify near the top of the file, assuming it is made available as a module or global. Since we are allowed to add well-known libraries, we’ll import it as a module (the project’s bundling specifics are unknown, but this is the least intrusive code change).
2. In the mermaid rendering block, directly before `const parser = new DOMParser();` (line 253–254 area), create a sanitized SVG string:  
   `const sanitizedSvg = DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true } });`
3. Replace the use of the raw `svg` in `parseFromString` with `sanitizedSvg`. Everything else (error checking, `parsererror` handling, node import, container replacement) remains as-is.

This preserves existing functionality (still renders diagrams as SVG) while ensuring that any active or dangerous markup in the SVG is stripped before insertion.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
